### PR TITLE
fix: safeguard grid mount when tables container missing

### DIFF
--- a/proto/ui/index.html
+++ b/proto/ui/index.html
@@ -230,7 +230,7 @@
     </div>
     <div id="grid-${key}" class="ag-theme-quartz"></div>
   `;
-  if (typeof tablesEl !== 'undefined') {
+  if (tablesEl) {
     tablesEl.appendChild(sec);
   }
 


### PR DESCRIPTION
## Summary
- prevent crash when tables container is absent by checking for element before mounting grid

## Testing
- `npm test >/tmp/test.log 2>&1; tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68a71bfb378c8327a1159508af67867c