### PR TITLE
Add PatientWithVisits form with tabbed visits

### DIFF
--- a/proto/ui/forms/patient_with_visits/formData.json
+++ b/proto/ui/forms/patient_with_visits/formData.json
@@ -1,0 +1,23 @@
+{
+  "code": "P-0001",
+  "last_name": "Петров",
+  "first_name": "Пётр",
+  "middle_name": "Петрович",
+  "sex": "male",
+  "visits": [
+    {
+      "visit_date": "2024-01-10",
+      "clinical_outcome_id": 1,
+      "hospital_tests": [
+        { "name": "ALT (U/L)", "value_text": "32" }
+      ]
+    },
+    {
+      "visit_date": "2024-02-20",
+      "clinical_outcome_id": 2,
+      "hospital_tests": [
+        { "name": "AST (U/L)", "value_text": "28" }
+      ]
+    }
+  ]
+}

--- a/proto/ui/forms/patient_with_visits/schema.json
+++ b/proto/ui/forms/patient_with_visits/schema.json
@@ -1,0 +1,44 @@
+{
+  "title": "Пациент с визитами",
+  "type": "object",
+  "required": ["code", "last_name", "first_name", "sex"],
+  "properties": {
+    "code": { "type": "string", "title": "Код пациента" },
+    "last_name": { "type": "string", "title": "Фамилия" },
+    "first_name": { "type": "string", "title": "Имя" },
+    "middle_name": { "type": "string", "title": "Отчество" },
+    "sex": {
+      "title": "Пол",
+      "enum": ["male", "female", "other"],
+      "enumNames": ["Мужской", "Женский", "Другое/не указано"]
+    },
+    "visits": {
+      "type": "array",
+      "title": "Визиты",
+      "items": {
+        "type": "object",
+        "required": ["visit_date"],
+        "properties": {
+          "visit_date": { "type": "string", "format": "date", "title": "Дата визита" },
+          "clinical_outcome_id": {
+            "title": "Клинический исход",
+            "enum": [1, 2, 3],
+            "enumNames": ["Улучшение", "Без изменений", "Ухудшение"]
+          },
+          "hospital_tests": {
+            "type": "array",
+            "title": "Больничные анализы",
+            "items": {
+              "type": "object",
+              "required": ["name", "value_text"],
+              "properties": {
+                "name": { "type": "string", "title": "Название (c ед.)" },
+                "value_text": { "type": "string", "title": "Значение" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/proto/ui/forms/patient_with_visits/uiSchema.json
+++ b/proto/ui/forms/patient_with_visits/uiSchema.json
@@ -1,0 +1,12 @@
+{
+  "visits": {
+    "ui:options": { "tabs": true },
+    "items": {
+      "hospital_tests": {
+        "items": {
+          "value_text": { "ui:placeholder": "например, 32" }
+        }
+      }
+    }
+  }
+}

--- a/proto/ui/index.html
+++ b/proto/ui/index.html
@@ -79,6 +79,7 @@
     const FORMS = [
       { key: 'user',              label: 'Пользователь' },
       { key: 'patient',           label: 'Пациент' },
+      { key: 'patient_with_visits', label: 'Пациент с визитами' },
       { key: 'visit',             label: 'Визит' },
       { key: 'hospital_test',     label: 'Больничный анализ' },
       { key: 'lab_genetics',      label: 'Лаборатория — генетика' },


### PR DESCRIPTION
## Summary
- add new PatientWithVisits composite form with nested visit tabs
- expose PatientWithVisits in demo form selector

## Testing
- `npm test` (fails: Error: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_68a7283459908327a9703b352770deeb