### PR TITLE
Render full visit forms in patient tabs

### DIFF
--- a/proto/ui/forms/patient_with_visits/formData.json
+++ b/proto/ui/forms/patient_with_visits/formData.json
@@ -1,0 +1,31 @@
+{
+  "code": "P-0001",
+  "last_name": "Петров",
+  "first_name": "Пётр",
+  "middle_name": "Петрович",
+  "sex": "male",
+  "visits": [
+    {
+      "visit_date": "2024-01-10",
+      "age_at_visit_years": 45,
+      "weight_kg": 82.5,
+      "height_cm": 178,
+      "sex_at_visit": "male",
+      "clinical_outcome_id": 1,
+      "drug_intakes": [ { "drug_id": 1, "dose_id": 2 } ],
+      "hospital_tests": [ { "name": "ALT (U/L)", "value_text": "32" } ],
+      "lab_concentrations": [ { "drug_id": 1, "value_num": 1.4, "unit_id": 3 } ]
+    },
+    {
+      "visit_date": "2024-02-20",
+      "age_at_visit_years": 46,
+      "weight_kg": 83.0,
+      "height_cm": 178,
+      "sex_at_visit": "male",
+      "clinical_outcome_id": 2,
+      "drug_intakes": [ { "drug_id": 2, "dose_id": 1 } ],
+      "hospital_tests": [ { "name": "AST (U/L)", "value_text": "28" } ],
+      "lab_phenotyping": [ { "drug_id": 2, "metabolites": [ { "metabolite_name": "M1", "value_num": 0.5, "unit_id": 3 } ] } ]
+    }
+  ]
+}

--- a/proto/ui/forms/patient_with_visits/schema.json
+++ b/proto/ui/forms/patient_with_visits/schema.json
@@ -1,0 +1,161 @@
+{
+  "title": "Пациент с визитами",
+  "type": "object",
+  "required": ["code", "last_name", "first_name", "sex"],
+  "properties": {
+    "code": { "type": "string", "title": "Код пациента" },
+    "last_name": { "type": "string", "title": "Фамилия" },
+    "first_name": { "type": "string", "title": "Имя" },
+    "middle_name": { "type": "string", "title": "Отчество" },
+    "sex": {
+      "title": "Пол",
+      "enum": ["male", "female", "other"],
+      "enumNames": ["Мужской", "Женский", "Другое/не указано"]
+    },
+    "visits": {
+      "type": "array",
+      "title": "Визиты",
+      "items": {
+        "type": "object",
+        "required": ["visit_date"],
+        "properties": {
+          "visit_date": { "type": "string", "format": "date", "title": "Дата визита" },
+          "age_at_visit_years": { "type": "number", "title": "Возраст (лет)", "minimum": 0 },
+          "weight_kg": { "type": "number", "title": "Вес (кг)", "minimum": 0 },
+          "height_cm": { "type": "number", "title": "Рост (см)", "minimum": 0 },
+          "sex_at_visit": {
+            "title": "Пол на дату визита",
+            "enum" : ["male", "female", "other"],
+            "enumNames" : ["Мужской", "Женский", "Другое/не указано"]
+          },
+          "additional_disease_text": { "type": "string", "title": "Доп. заболевание" },
+          "referral_text": { "type": "string", "title": "Направление" },
+          "clinical_outcome_id": {
+            "title": "Клинический исход",
+            "enum": [1, 2, 3],
+            "enumNames": ["Улучшение", "Без изменений", "Ухудшение"]
+          },
+          "drug_intakes": {
+            "type": "array",
+            "title": "Принимаемые препараты",
+            "items": {
+              "type": "object",
+              "required": ["drug_id"],
+              "properties": {
+                "drug_id": {
+                  "title": "Препарат",
+                  "enum" : [1, 2],
+                  "enumNames" : ["Препарат X", "Препарат Y"]
+                },
+                "dose_id": {
+                  "title": "Доза",
+                  "enum" : [1, 2],
+                  "enumNames" : ["5 mg", "10 mg"]
+                }
+              }
+            }
+          },
+          "hospital_tests": {
+            "type": "array",
+            "title": "Больничные анализы",
+            "items": {
+              "type": "object",
+              "required": ["name", "value_text"],
+              "properties": {
+                "name": { "type": "string", "title": "Название (c ед.)", "examples": ["ALT (U/L)"] },
+                "value_text": { "type": "string", "title": "Значение" }
+              }
+            }
+          },
+          "lab_genetics": {
+            "type": "array",
+            "title": "Генетика",
+            "items": {
+              "type": "object",
+              "required": ["analyte_name", "value_text"],
+              "properties": {
+                "analyte_name": { "type": "string", "title": "Маркер/ген/вариант" },
+                "value_text": { "type": "string", "title": "Значение" },
+                "unit_id": {
+                  "title": "Ед. изм.",
+                  "enum": [1, 2],
+                  "enumNames" : ["ед.", "мг/л"]
+                }
+              }
+            }
+          },
+          "lab_concentrations": {
+            "type": "array",
+            "title": "Концентрация ЛП",
+            "items": {
+              "type": "object",
+              "required": ["drug_id", "value_num"],
+              "properties": {
+                "drug_id": {
+                  "title": "Препарат",
+                  "enum" : [1, 2],
+                  "enumNames" : ["Препарат X", "Препарат Y"]
+                },
+                "value_num": { "type": "number", "title": "Значение" },
+                "unit_id": {
+                  "title": "Ед. изм.",
+                  "enum": [2, 3],
+                  "enumNames": ["мг/л", "нг/мл"]
+                }
+              }
+            }
+          },
+          "lab_phenotyping": {
+            "type": "array",
+            "title": "Фенотипирование",
+            "items": {
+              "type": "object",
+              "required": ["drug_id"],
+              "properties": {
+                "drug_id": {
+                  "title": "Препарат",
+                  "enum" : [1, 2],
+                  "enumNames" : ["Препарат X", "Препарат Y"]
+                },
+                "metabolites": {
+                  "type": "array",
+                  "title": "Метаболиты",
+                  "items": {
+                    "type": "object",
+                    "required": ["metabolite_name", "value_num"],
+                    "properties": {
+                      "metabolite_name": { "type": "string", "title": "Назвние" },
+                      "value_num": { "type": "number", "title": "Значение" },
+                      "unit_id": {
+                        "title": "Ед. изм.",
+                        "enum": [2, 3],
+                        "enumNames": ["мг/л", "нг/мл"]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "lab_microrna": {
+            "type": "array",
+            "title": "микроРНК",
+            "items": {
+              "type": "object",
+              "required": ["analyte_name", "value_num"],
+              "properties": {
+                "analyte_name": { "type": "string", "title": "Название" },
+                "value_num": { "type": "number", "title": "Значение" },
+                "unit_id": {
+                  "title": "Ед. изм.",
+                  "enum": [4],
+                  "enumNames" : ["ед."]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/proto/ui/forms/patient_with_visits/uiSchema.json
+++ b/proto/ui/forms/patient_with_visits/uiSchema.json
@@ -1,0 +1,13 @@
+{
+  "visits": {
+    "ui:options": { "tabs": true, "tabNameField": "visit_date" },
+    "items": {
+      "additional_disease_text": { "ui:widget": "textarea", "ui:options": { "rows": 2 } },
+      "referral_text": { "ui:widget": "textarea", "ui:options": { "rows": 2 } },
+      "hospital_tests": { "items": { "value_text": { "ui:placeholder": "например, 32" } } },
+      "lab_genetics": { "items": { "unit_id": { "ui:placeholder": "ед. изм." } } },
+      "lab_concentrations": { "items": { "unit_id": { "ui:placeholder": "ед. изм." } } },
+      "lab_phenotyping": { "items": { "metabolites": { "items": { "unit_id": { "ui:placeholder": "ед. изм." } } } } }
+    }
+  }
+}

--- a/proto/ui/index.html
+++ b/proto/ui/index.html
@@ -79,6 +79,7 @@
     const FORMS = [
       { key: 'user',              label: 'Пользователь' },
       { key: 'patient',           label: 'Пациент' },
+      { key: 'patient_with_visits', label: 'Пациент с визитами' },
       { key: 'visit',             label: 'Визит' },
       { key: 'hospital_test',     label: 'Больничный анализ' },
       { key: 'lab_genetics',      label: 'Лаборатория — генетика' },
@@ -118,13 +119,15 @@
     }
 
     // Разделяем схему: скалярные свойства -> в rjsf, массивы -> в AG Grid
-    function splitSchema(schema){
+    function splitSchema(schema, uiSchema){
       const base = JSON.parse(JSON.stringify(schema||{}));
       const arrays = [];
       if (base && base.properties){
         for (const [key, prop] of Object.entries(base.properties)){
           if (prop && prop.type === 'array' && prop.items && (prop.items.type === 'object' || prop.items.properties)){
-            arrays.push({ key, title: prop.title || key, schema: prop });
+            const ui = uiSchema && uiSchema[key];
+            const useTabs = ui && ui['ui:options'] && ui['ui:options'].tabs;
+            arrays.push({ key, title: prop.title || key, schema: prop, uiSchema: ui || {}, useTabs });
           }
         }
         // удалить массивы из rjsf-схемы
@@ -219,7 +222,7 @@
     }
 
     // Создать секцию-таблицу на странице и вернуть Grid API
-    function mountGrid(sectionTitle, key, cols, rows, blankRow) {
+    function mountGrid(sectionTitle, key, cols, rows, blankRow, container) {
   // создаём секцию с заголовком и контейнером грида
   const sec = document.createElement('div');
   sec.className = 'grid-section';
@@ -231,7 +234,7 @@
     <div id="grid-${key}" class="ag-theme-quartz"></div>
   `;
   if (typeof tablesEl !== 'undefined') {
-    tablesEl.appendChild(sec);
+    (container || tablesEl).appendChild(sec);
   }
 
   const el = document.getElementById(`grid-${key}`);
@@ -284,10 +287,117 @@
 }
 
 
+    function mountTabbedArray(sectionTitle, key, arrSchema, arrUi, initialData) {
+      const sec = document.createElement('div');
+      sec.className = 'grid-section';
+      sec.innerHTML = `
+        <div class="grid-head" style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px;">
+          <h4 class="mb-0" style="font-family:inherit;font-weight:600;">${sectionTitle}</h4>
+          <button class="btn btn-sm btn-success" id="btn-add-${key}">+ Добавить визит</button>
+        </div>
+        <div id="tabs-${key}"></div>
+      `;
+      tablesEl.appendChild(sec);
+      const tabsEl = document.getElementById(`tabs-${key}`);
+      let active = 0;
+      let data = Array.isArray(initialData) ? initialData.slice() : [];
+      let records = [];
 
-    // состояние спецификаций таблиц и API текущей формы
-    let tableSpecs = [];
-    let apis = {}; // key -> gridApi
+      function renderTabs(){
+        data = records.map(r=> r.getData());
+        records = [];
+        tabsEl.innerHTML='';
+        const nav = document.createElement('ul');
+        nav.className = 'nav nav-tabs';
+        tabsEl.appendChild(nav);
+        const content = document.createElement('div');
+        tabsEl.appendChild(content);
+
+        data.forEach((d, idx)=>{
+          const li = document.createElement('li');
+          li.className = 'nav-item';
+          const a = document.createElement('a');
+          a.className = 'nav-link'+(idx===active?' active':'');
+          a.href = '#';
+          li.appendChild(a);
+          nav.appendChild(li);
+          a.onclick = e=>{ e.preventDefault(); active=idx; renderTabs(); };
+
+          const pane = document.createElement('div');
+          pane.style.display = idx===active?'block':'none';
+          pane.style.border = '1px solid #dee2e6';
+          pane.style.borderTop = 'none';
+          pane.style.padding = '10px';
+          content.appendChild(pane);
+
+          const rec = renderVisitPane(pane, idx, d, a);
+          records.push(rec);
+        });
+      }
+
+      function renderVisitPane(pane, idx, d, anchor){
+        let visitData = JSON.parse(JSON.stringify(d || {}));
+        const innerSpecs = [];
+        const innerApis = {};
+        const { baseSchema: vBase, arrays: vArrays } = splitSchema(arrSchema.items, arrUi && arrUi.items);
+        const formDiv = document.createElement('div');
+        pane.appendChild(formDiv);
+        function updateLabel(){
+          const titleField = arrUi && arrUi['ui:options'] && arrUi['ui:options'].tabNameField;
+          let label = `Визит ${idx+1}`;
+          if (titleField && visitData && visitData[titleField]) label = visitData[titleField];
+          anchor.textContent = label;
+        }
+        const onChange = ({formData})=>{ visitData = formData; updateLabel(); };
+        ReactDOM.render(React.createElement(Form, { schema: vBase, uiSchema: arrUi && arrUi.items, formData: visitData, onChange }), formDiv);
+        vArrays.forEach(vArr=>{
+          const itemProps = (vArr.schema.items && vArr.schema.items.properties) || {};
+          const hasOneSubArray = Object.values(itemProps).filter(p=> p && p.type==='array').length === 1;
+          let spec;
+          if (hasOneSubArray) spec = buildFlattenTableSpec(vArr.key, vArr.schema, visitData[vArr.key]);
+          else spec = buildSimpleTableSpec(vArr.key, vArr.schema, visitData[vArr.key]);
+          const gridKey = `${key}-${idx}-${vArr.key}`;
+          const api = mountGrid(vArr.title || vArr.key, gridKey, spec.cols, spec.rows, spec.blank, pane);
+          innerSpecs.push({ key: vArr.key, spec });
+          innerApis[vArr.key] = api;
+        });
+        const removeBtn = document.createElement('button');
+        removeBtn.type='button';
+        removeBtn.className='btn btn-outline-danger btn-sm mt-2';
+        removeBtn.textContent='Удалить визит';
+        removeBtn.onclick = ()=>{
+          data = records.map(r=> r.getData());
+          data.splice(idx,1);
+          if (active >= data.length) active = data.length-1;
+          renderTabs();
+        };
+        pane.appendChild(removeBtn);
+        updateLabel();
+        return {
+          getData: ()=>{
+            const res = { ...visitData };
+            innerSpecs.forEach(s=>{
+              const rows=[];
+              const api = innerApis[s.key];
+              if (api) api.forEachNode(n=> rows.push({ ...n.data }));
+              res[s.key] = s.spec.regroup ? s.spec.regroup(rows) : rows;
+            });
+            return res;
+          }
+        };
+      }
+
+      const addBtn = document.getElementById(`btn-add-${key}`);
+      if (addBtn) addBtn.onclick = ()=>{ data = records.map(r=> r.getData()); data.push({}); active = data.length-1; renderTabs(); };
+
+      renderTabs();
+
+      return { getData: ()=> records.map(r=> r.getData()) };
+    }
+
+
+    // состояние спецификаций массивов текущей формы
+    let arraySpecs = [];
 
     // Основной рендер
     async function render(name){
@@ -303,7 +413,7 @@
         titleEl.textContent = (schema.title||name) + (schema.description? ' — '+schema.description : '');
 
         // делим схему: поля в rjsf, массивы в гриды
-        const { baseSchema, arrays } = splitSchema(schema);
+        const { baseSchema, arrays } = splitSchema(schema, uiSchema);
 
         // рендер rjsf
         const actions = React.createElement('div',{className:'actions'},
@@ -311,34 +421,33 @@
           React.createElement('button',{type:'reset', className:'btn btn-outline-secondary'},'Reset')
         );
         const onSubmit = ({formData: scalarData})=>{
-          // собрать данные из таблиц
           const result = { ...scalarData };
-          tableSpecs.forEach(s => {
-            const list = [];
-            const api = apis[s.key];
-            if (api) api.forEachNode(n=> list.push({...n.data}));
-            result[s.key] = s.regroup(list);
-          });
+          arraySpecs.forEach(s => { result[s.key] = s.getData(); });
           alert('Submitted:' + JSON.stringify(result, null, 2));
         };
         ReactDOM.render(React.createElement(Form, { schema: baseSchema, uiSchema, formData, onSubmit }, actions), appEl);
 
-        // отрисовать таблицы
+        // отрисовать массивы
         tablesEl.innerHTML='';
-        Object.values(apis).forEach(api=> api && api.destroy && api.destroy());
-        apis = {}; // сбросить
-        tableSpecs = []; // сбросить
+        arraySpecs = [];
 
         for (const arr of arrays){
-          // если внутри есть один подмассив — делаем flatten, иначе — обычная таблица
+          if (arr.useTabs) {
+            const spec = mountTabbedArray(arr.title || arr.key, arr.key, arr.schema, arr.uiSchema, formData[arr.key]);
+            arraySpecs.push({ key: arr.key, getData: spec.getData });
+            continue;
+          }
           const itemProps = (arr.schema.items && arr.schema.items.properties) || {};
           const hasOneSubArray = Object.values(itemProps).filter(p=> p && p.type==='array').length === 1;
           let spec;
           if (hasOneSubArray) spec = buildFlattenTableSpec(arr.key, arr.schema, formData[arr.key]);
           else spec = buildSimpleTableSpec(arr.key, arr.schema, formData[arr.key]);
           const api = mountGrid(arr.title || arr.key, spec.key, spec.cols, spec.rows, spec.blank);
-          apis[spec.key] = api;
-          tableSpecs.push(spec);
+          arraySpecs.push({ key: spec.key, getData: () => {
+            const list = [];
+            if (api) api.forEachNode(n=> list.push({ ...n.data }));
+            return spec.regroup(list);
+          }});
         }
       } catch (e) {
         console.error(e);


### PR DESCRIPTION
## Summary
- add mountTabbedArray helper that renders array items in Bootstrap nav-tabs with per-tab visit forms and nested tables
- extend PatientWithVisits schema, UI schema, and sample data to include full visit fields

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68a7283459908327a9703b352770deeb